### PR TITLE
Dani/aot raw writer

### DIFF
--- a/Mono.Cecil.Cil/CodeReader.cs
+++ b/Mono.Cecil.Cil/CodeReader.cs
@@ -55,11 +55,21 @@ namespace Mono.Cecil.Cil {
 		{
 			var position = MoveTo (method);
 			this.body = new MethodBody (method);
+			var initialOffset = Position;
 
 			ReadMethodBody ();
 
+			body.RawBody = GetReadBuffer ();
+
 			MoveBackTo (position);
 			return this.body;
+
+			byte [] GetReadBuffer ()
+			{
+				var len = Position - initialOffset;
+				Position = initialOffset;
+				return ReadBytes(len);
+			}
 		}
 
 		public int ReadCodeSize (MethodDefinition method)

--- a/Mono.Cecil.Cil/CodeWriter.cs
+++ b/Mono.Cecil.Cil/CodeWriter.cs
@@ -76,6 +76,10 @@ namespace Mono.Cecil.Cil {
 		RVA WriteRawBody (MethodDefinition method)
 		{
 			var raw_body = method.Body.RawBody;
+			var fat_header = (raw_body [0] & 0x3) == 0x3;
+			if (fat_header)
+				Align (4);
+
 			var rva = BeginMethod ();
 			WriteBytes (raw_body);
 			return rva;

--- a/Mono.Cecil.Cil/CodeWriter.cs
+++ b/Mono.Cecil.Cil/CodeWriter.cs
@@ -42,6 +42,11 @@ namespace Mono.Cecil.Cil {
 		{
 			RVA rva;
 
+			if (method.Body != null && method.Body.RawBody != null && method.Body.RawBody.Length > 0) {
+				rva = WriteRawBody (method);
+				return rva;
+			}
+
 			if (IsUnresolved (method)) {
 				if (method.rva == 0)
 					return 0;
@@ -66,6 +71,14 @@ namespace Mono.Cecil.Cil {
 		static bool IsUnresolved (MethodDefinition method)
 		{
 			return method.HasBody && method.HasImage && method.body == null;
+		}
+
+		RVA WriteRawBody (MethodDefinition method)
+		{
+			var raw_body = method.Body.RawBody;
+			var rva = BeginMethod ();
+			WriteBytes (raw_body);
+			return rva;
 		}
 
 		RVA WriteUnresolvedMethodBody (MethodDefinition method)
@@ -608,6 +621,14 @@ namespace Mono.Cecil.Cil {
 				break;
 			}
 		}
+
+		public MetadataToken GetStandAloneSignature (byte [] rawSig)
+		{
+			var signature = metadata.GetLocalVariableBlobIndex (rawSig);
+
+			return GetStandAloneSignatureToken (signature);
+		}
+
 
 		public MetadataToken GetStandAloneSignature (Collection<VariableDefinition> variables)
 		{

--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -29,6 +29,8 @@ namespace Mono.Cecil.Cil {
 		internal Collection<ExceptionHandler> exceptions;
 		internal Collection<VariableDefinition> variables;
 
+		public byte [] RawBody { get; set; }
+
 		public MethodDefinition Method {
 			get { return method; }
 		}

--- a/Mono.Cecil.Metadata/BlobHeap.cs
+++ b/Mono.Cecil.Metadata/BlobHeap.cs
@@ -9,6 +9,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 
 namespace Mono.Cecil.Metadata {
 
@@ -34,6 +35,8 @@ namespace Mono.Cecil.Metadata {
 
 			Buffer.BlockCopy (data, position, buffer, 0, length);
 
+			Blobs [index] = buffer;
+
 			return buffer;
 		}
 
@@ -50,5 +53,7 @@ namespace Mono.Cecil.Metadata {
 			index = (int) signature;
 			length = (int) buffer.ReadCompressedUInt32 (ref index);
 		}
+
+		internal Dictionary<uint, byte []> Blobs = new Dictionary<uint, byte []> ();
 	}
 }

--- a/Mono.Cecil.Metadata/StringHeap.cs
+++ b/Mono.Cecil.Metadata/StringHeap.cs
@@ -56,5 +56,7 @@ namespace Mono.Cecil.Metadata {
 
 			return Encoding.UTF8.GetString (data, start, length);
 		}
+
+		internal Dictionary<uint, string> Strings => strings;
 	}
 }

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -2526,6 +2526,10 @@ namespace Mono.Cecil {
 				foreach (var custom_attribute in custom_attributes)
 					WindowsRuntimeProjections.Project (owner, custom_attributes, custom_attribute);
 
+			foreach (var attribute in custom_attributes) { 
+				attribute.Owner = owner;
+			}
+
 			return custom_attributes;
 		}
 

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -2531,6 +2531,7 @@ namespace Mono.Cecil {
 
 		void ReadCustomAttributeRange (Range range, Collection<CustomAttribute> custom_attributes)
 		{
+			var token = new MetadataToken (TokenType.CustomAttribute, range.Start);
 			if (!MoveTo (Table.CustomAttribute, range.Start))
 				return;
 
@@ -2542,7 +2543,7 @@ namespace Mono.Cecil {
 
 				var signature = ReadBlobIndex ();
 
-				custom_attributes.Add (new CustomAttribute (signature, constructor));
+				custom_attributes.Add (new CustomAttribute (token, signature, constructor));
 			}
 		}
 

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -205,6 +205,7 @@ namespace Mono.Cecil {
 			ReadCustomAttributes (assembly);
 			ReadSecurityDeclarations (assembly);
 
+			module.IsDirty = false;
 		}
 
 		void ReadTypes (Collection<TypeDefinition> types)

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -3340,6 +3340,16 @@ namespace Mono.Cecil {
 			this.start = (uint) this.position;
 		}
 
+		public SignatureReader (byte [] data, MetadataReader reader)
+			: base (data)
+		{
+			this.reader = reader;
+			this.position = 0;
+			this.sig_length = (uint)data.Length;
+			this.start = (uint)this.position;
+		}
+
+
 		MetadataToken ReadTypeTokenSignature ()
 		{
 			return CodedIndex.TypeDefOrRef.GetMetadataToken (ReadCompressedUInt32 ());

--- a/Mono.Cecil/CallSite.cs
+++ b/Mono.Cecil/CallSite.cs
@@ -19,6 +19,8 @@ namespace Mono.Cecil {
 
 		readonly MethodReference signature;
 
+		public byte [] RawSignature { get => signature.RawSignature; set => signature.RawSignature = value; }
+
 		public bool HasThis {
 			get { return signature.HasThis; }
 			set { signature.HasThis = value; }

--- a/Mono.Cecil/CustomAttribute.cs
+++ b/Mono.Cecil/CustomAttribute.cs
@@ -81,6 +81,8 @@ namespace Mono.Cecil {
 		internal Collection<CustomAttributeNamedArgument> fields;
 		internal Collection<CustomAttributeNamedArgument> properties;
 
+		public MetadataToken MetadataToken { get; set; }
+
 		public MethodReference Constructor {
 			get { return constructor; }
 			set { constructor = value; }
@@ -159,8 +161,9 @@ namespace Mono.Cecil {
 			get { return constructor.Module; }
 		}
 
-		internal CustomAttribute (uint signature, MethodReference constructor)
+		internal CustomAttribute (MetadataToken token, uint signature, MethodReference constructor)
 		{
+			this.MetadataToken = token;
 			this.signature = signature;
 			this.constructor = constructor;
 			this.resolved = false;

--- a/Mono.Cecil/CustomAttribute.cs
+++ b/Mono.Cecil/CustomAttribute.cs
@@ -83,6 +83,8 @@ namespace Mono.Cecil {
 
 		public MetadataToken MetadataToken { get; set; }
 
+		public IMetadataTokenProvider Owner { get; set; }
+
 		public MethodReference Constructor {
 			get { return constructor; }
 			set { constructor = value; }

--- a/Mono.Cecil/FieldDefinition.cs
+++ b/Mono.Cecil/FieldDefinition.cs
@@ -28,6 +28,8 @@ namespace Mono.Cecil {
 
 		MarshalInfo marshal_info;
 
+		public byte [] RawSignature { get; set; }
+
 		void ResolveLayout ()
 		{
 			if (offset != Mixin.NotResolvedMarker)
@@ -266,6 +268,15 @@ namespace Mono.Cecil {
 			: base (name, fieldType)
 		{
 			this.attributes = (ushort) attributes;
+		}
+
+		public FieldDefinition (string name, FieldAttributes attributes, byte[] sig, TypeDefinition declaringType)
+			: base ()
+		{
+			this.Name = name;
+			this.RawSignature = sig;
+			this.attributes = (ushort)attributes;
+			this.DeclaringType = declaringType;
 		}
 
 		public override FieldDefinition Resolve ()

--- a/Mono.Cecil/FunctionPointerType.cs
+++ b/Mono.Cecil/FunctionPointerType.cs
@@ -18,6 +18,7 @@ namespace Mono.Cecil {
 	public sealed class FunctionPointerType : TypeSpecification, IMethodSignature {
 
 		readonly MethodReference function;
+		public byte [] RawSignature { get => function.RawSignature; set => function.RawSignature = value; }
 
 		public bool HasThis {
 			get { return function.HasThis; }

--- a/Mono.Cecil/IGenericInstance.cs
+++ b/Mono.Cecil/IGenericInstance.cs
@@ -18,6 +18,8 @@ namespace Mono.Cecil {
 
 		bool HasGenericArguments { get; }
 		Collection<TypeReference> GenericArguments { get; }
+
+		byte [] RawSignature { get; set; }
 	}
 
 	static partial class Mixin {

--- a/Mono.Cecil/IMethodSignature.cs
+++ b/Mono.Cecil/IMethodSignature.cs
@@ -24,6 +24,8 @@ namespace Mono.Cecil {
 		Collection<ParameterDefinition> Parameters { get; }
 		TypeReference ReturnType { get; set; }
 		MethodReturnType MethodReturnType { get; }
+
+		byte[] RawSignature { get; set; }
 	}
 
 	static partial class Mixin {

--- a/Mono.Cecil/MemberReference.cs
+++ b/Mono.Cecil/MemberReference.cs
@@ -20,6 +20,8 @@ namespace Mono.Cecil {
 		internal MetadataToken token;
 		internal object projection;
 
+		public byte [] RawSignature { get; set; }
+
 		public virtual string Name {
 			get { return name; }
 			set {

--- a/Mono.Cecil/MetadataSystem.cs
+++ b/Mono.Cecil/MetadataSystem.cs
@@ -65,6 +65,11 @@ namespace Mono.Cecil {
 		internal Dictionary<uint, uint> StateMachineMethods;
 		internal Dictionary<MetadataToken, Row<Guid, uint, uint> []> CustomDebugInformations;
 
+
+		internal Dictionary<uint, TypeReference> TypeSpecs = new Dictionary<uint, TypeReference> ();
+		internal Dictionary<uint, MethodSpecification> MethodSpecs = new Dictionary<uint, MethodSpecification> ();
+		internal Dictionary<MetadataToken, Tuple<int, GenericParameterAttributes, MetadataToken, string>> GenericParams = new System.Collections.Generic.Dictionary<MetadataToken, Tuple<int, GenericParameterAttributes, MetadataToken, string>> ();
+		internal Dictionary<MetadataToken, Tuple<MetadataToken, MetadataToken>> GenericParamConstraints = new System.Collections.Generic.Dictionary<MetadataToken, Tuple<MetadataToken, MetadataToken>> ();
 		internal Dictionary<MetadataToken, byte []> StandAloneSigs = new Dictionary<MetadataToken, byte []>();
 		internal Dictionary<uint, string> UserStrings = new Dictionary<uint, string> ();
 		internal UserStringHeapBuffer UserStringsHeap = new UserStringHeapBuffer ();

--- a/Mono.Cecil/MetadataSystem.cs
+++ b/Mono.Cecil/MetadataSystem.cs
@@ -65,6 +65,10 @@ namespace Mono.Cecil {
 		internal Dictionary<uint, uint> StateMachineMethods;
 		internal Dictionary<MetadataToken, Row<Guid, uint, uint> []> CustomDebugInformations;
 
+		internal Dictionary<MetadataToken, byte []> StandAloneSigs = new Dictionary<MetadataToken, byte []>();
+		internal Dictionary<uint, string> UserStrings = new Dictionary<uint, string> ();
+		internal UserStringHeapBuffer UserStringsHeap = new UserStringHeapBuffer ();
+
 		static Dictionary<string, Row<ElementType, bool>> primitive_value_types;
 
 		static void InitializePrimitives ()
@@ -378,5 +382,6 @@ namespace Mono.Cecil {
 
 			return null;
 		}
+
 	}
 }

--- a/Mono.Cecil/MethodDefinition.cs
+++ b/Mono.Cecil/MethodDefinition.cs
@@ -511,6 +511,16 @@ namespace Mono.Cecil {
 			this.token = new MetadataToken (TokenType.Method);
 		}
 
+		public MethodDefinition (string name, MethodAttributes attributes, byte[] sig, TypeDefinition declaringType)
+		{
+			this.Name = name;
+			this.attributes = (ushort)attributes;
+			this.RawSignature = sig;
+			this.DeclaringType = declaringType;
+			this.token = new MetadataToken (TokenType.Method);
+		}
+
+
 		public override MethodDefinition Resolve ()
 		{
 			return this;

--- a/Mono.Cecil/MethodReference.cs
+++ b/Mono.Cecil/MethodReference.cs
@@ -25,8 +25,6 @@ namespace Mono.Cecil {
 		MethodCallingConvention calling_convention;
 		internal Collection<GenericParameter> generic_parameters;
 
-		public byte [] RawSignature { get; set; }
-
 		public virtual bool HasThis {
 			get { return has_this; }
 			set { has_this = value; }

--- a/Mono.Cecil/MethodReference.cs
+++ b/Mono.Cecil/MethodReference.cs
@@ -25,6 +25,8 @@ namespace Mono.Cecil {
 		MethodCallingConvention calling_convention;
 		internal Collection<GenericParameter> generic_parameters;
 
+		public byte [] RawSignature { get; set; }
+
 		public virtual bool HasThis {
 			get { return has_this; }
 			set { has_this = value; }
@@ -156,6 +158,13 @@ namespace Mono.Cecil {
 		{
 			Mixin.CheckType (declaringType, Mixin.Argument.declaringType);
 
+			this.DeclaringType = declaringType;
+		}
+
+		public MethodReference (string name, byte [] sig, TypeReference declaringType)
+			: base (name)
+		{ 
+			RawSignature = sig;
 			this.DeclaringType = declaringType;
 		}
 

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -294,7 +294,7 @@ namespace Mono.Cecil {
 
 			var offset = MetadataSystem.UserStringsHeap.GetStringIndex(userString);
 			MetadataSystem.UserStrings [offset] = userString;
-			return new MetadataToken (offset);
+			return new MetadataToken (TokenType.String, offset);
 		}
 
 		public MetadataToken AddRaw (byte [] signature)
@@ -344,6 +344,11 @@ namespace Mono.Cecil {
 		public MethodDefinition AddRaw (MethodDefinition value)
 		{
 			IsDirty = true;
+
+			if (value.RawSignature != null && value.RawSignature.Length > 0) {
+				var signatureReader = new SignatureReader (value.RawSignature, reader);
+				signatureReader.ReadMethodSignature (value);
+			}
 
 			value.MetadataToken = new MetadataToken (TokenType.Method, MetadataSystem.Methods.Length + 1);
 			var values = MetadataSystem.Methods.ToList ();

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -283,15 +283,24 @@ namespace Mono.Cecil {
 
 		#region RAW methods
 
+		public bool IsDirty {
+			get;
+			internal set;
+		} = false;
+
 		public MetadataToken AddRaw (string userString)
 		{
+			IsDirty = true;
+
 			var offset = MetadataSystem.UserStringsHeap.GetStringIndex(userString);
 			MetadataSystem.UserStrings [offset] = userString;
 			return new MetadataToken (offset);
 		}
 
 		public MetadataToken AddRaw (byte [] signature)
-		{ 
+		{
+			IsDirty = true;
+
 			var token = new MetadataToken (TokenType.Signature, MetadataSystem.StandAloneSigs.Count + 1);
 			MetadataSystem.StandAloneSigs[token] = signature;
 			return token;
@@ -299,6 +308,8 @@ namespace Mono.Cecil {
 
 		public ModuleReference AddRaw (ModuleReference value)
 		{
+			IsDirty = true;
+
 			value.MetadataToken = new MetadataToken (TokenType.ModuleRef, MetadataSystem.ModuleReferences.Length + 1);
 			var values = MetadataSystem.ModuleReferences.ToList ();
 			values.Add (value);
@@ -309,6 +320,8 @@ namespace Mono.Cecil {
 
 		public TypeDefinition AddRaw (TypeDefinition value)
 		{
+			IsDirty = true;
+
 			value.MetadataToken = new MetadataToken (TokenType.TypeDef, MetadataSystem.Types.Length + 1);
 			var values = MetadataSystem.Types.ToList ();
 			values.Add (value);
@@ -318,6 +331,8 @@ namespace Mono.Cecil {
 
 		public FieldDefinition AddRaw (FieldDefinition value)
 		{
+			IsDirty = true;
+
 			value.MetadataToken = new MetadataToken (TokenType.Field, MetadataSystem.Fields.Length + 1);
 			var values = MetadataSystem.Fields.ToList ();
 			values.Add (value);
@@ -328,6 +343,8 @@ namespace Mono.Cecil {
 
 		public MethodDefinition AddRaw (MethodDefinition value)
 		{
+			IsDirty = true;
+
 			value.MetadataToken = new MetadataToken (TokenType.Method, MetadataSystem.Methods.Length + 1);
 			var values = MetadataSystem.Methods.ToList ();
 			values.Add (value);
@@ -338,6 +355,8 @@ namespace Mono.Cecil {
 
 		public TypeReference AddRaw (TypeReference value)
 		{
+			IsDirty = true;
+
 			value.MetadataToken = new MetadataToken (TokenType.TypeRef, MetadataSystem.TypeReferences.Length + 1);
 			var values = MetadataSystem.TypeReferences.ToList ();
 			values.Add(value);
@@ -347,6 +366,8 @@ namespace Mono.Cecil {
 
 		public MemberReference AddRaw (MemberReference value)
 		{
+			IsDirty = true;
+
 			value.MetadataToken = new MetadataToken (TokenType.MemberRef, MetadataSystem.MemberReferences.Length + 1);
 			var values = MetadataSystem.MemberReferences.ToList ();
 			values.Add (value);

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -890,6 +890,15 @@ namespace Mono.Cecil {
 			return MetadataSystem.StandAloneSigs.Count;
 		}
 
+		public byte [] GetSignature(MetadataToken token)
+		{
+			if (token.TokenType == TokenType.Signature && MetadataSystem.StandAloneSigs.TryGetValue(token, out byte [] signature)) {
+				return signature;
+			}
+
+			return null;
+		}
+
 
 		public IEnumerable<CustomAttribute> GetCustomAttributes ()
 		{

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -354,6 +354,12 @@ namespace Mono.Cecil {
 			return value;
 		}
 
+		public string GetUserString(MetadataToken token)
+		{
+			MetadataSystem.UserStrings.TryGetValue(token.RID, out string text);
+			return text;
+		}
+
 		#endregion
 
 		public bool IsMain {

--- a/Mono.Cecil/RawMetadataBuilder.cs
+++ b/Mono.Cecil/RawMetadataBuilder.cs
@@ -112,7 +112,7 @@ namespace Mono.Cecil.Mono.Cecil {
 		protected override void AddTypes ()
 		{
 			foreach (var sig in GetAllStandaloneSigsSorted ()) {
-				var rva = GetBlobIndex (new SignatureWriter (sig.Value));
+				var rva = GetBlobIndex (sig.Value);
 				AddStandAloneSignature (rva);
 			}
 

--- a/Mono.Cecil/RawMetadataBuilder.cs
+++ b/Mono.Cecil/RawMetadataBuilder.cs
@@ -1,0 +1,163 @@
+﻿using Mono.Cecil.Cil;
+using Mono.Cecil.Metadata;
+using System.Collections.Generic;
+using System.Linq;
+using BlobIndex = System.UInt32;
+using CodedRID = System.UInt32;
+using GuidIndex = System.UInt32;
+using RID = System.UInt32;
+using RVA = System.UInt32;
+using StringIndex = System.UInt32;
+
+namespace Mono.Cecil.Mono.Cecil {
+	using TypeRefRow = Row<CodedRID, StringIndex, StringIndex>;
+
+	class RawMetadataBuilder : MetadataBuilder {
+		public RawMetadataBuilder (ModuleDefinition module, string fq_name, uint timestamp, ISymbolWriterProvider symbol_writer_provider)
+			: base (module, fq_name, timestamp, symbol_writer_provider)
+		{
+
+		}
+
+		public RawMetadataBuilder (ModuleDefinition module, PortablePdbWriterProvider writer_provider)
+			: base (module, writer_provider)
+		{
+		}
+
+		private bool buildRaw = false;
+
+		List<TypeDefinition> GetAllTypesSorted ()
+		{
+			var res = new List<TypeDefinition> (module.MetadataSystem.Types);
+			foreach (var type in module.Types) {
+				if (type.HasNestedTypes)
+					res.AddRange (type.NestedTypes);
+			}
+
+			res = res.OrderBy (i => i.MetadataToken.ToUInt32 ()).ToList ();
+			
+			foreach(var type in res) {
+				var fields = type.Fields.OrderBy(i => i.MetadataToken.ToUInt32()).ToList();
+				if(fields.Count > 0) {
+					type.fields_range.Start = fields [0].MetadataToken.RID;
+					type.fields_range.Length = (uint)fields.Count;
+				}
+				var methods = type.Methods.OrderBy (i => i.MetadataToken.ToUInt32 ()).ToList ();
+				if (methods.Count > 0) {
+					type.methods_range.Start = methods [0].MetadataToken.RID;
+					type.methods_range.Length = (uint)methods.Count;
+				}
+
+			}
+			return res;
+		}
+
+		List<FieldDefinition> GetAllFieldsSorted ()
+		{
+			var res = new List<FieldDefinition> (module.MetadataSystem.Fields);
+			res = res.OrderBy (i => i.MetadataToken.ToUInt32 ()).ToList ();
+			return res;
+		}
+
+		List<MethodDefinition> GetAllMethodsSorted ()
+		{
+			var res = new List<MethodDefinition> (module.MetadataSystem.Methods);
+			res = res.OrderBy (i => i.MetadataToken.ToUInt32 ()).ToList ();
+			return res;
+		}
+
+		List<TypeReference> GetAllTypeRefsSorted ()
+		{
+			return  module.GetTypeReferences().OrderBy (i => i.MetadataToken.ToUInt32 ()).ToList ();
+		}
+
+		List<MemberReference> GetAllMemberRefsSorted ()
+		{
+			return module.GetMemberReferences().OrderBy (i => i.MetadataToken.ToUInt32 ()).ToList ();
+		}
+
+		List<KeyValuePair<MetadataToken, byte[]>> GetAllStandaloneSigsSorted ()
+		{ 
+			return module.MetadataSystem.StandAloneSigs.OrderBy (i => i.Key.ToUInt32 ()).ToList();
+		}
+		List<KeyValuePair<RVA, string>> GetAllUserStringsSorted ()
+		{ 
+			return module.MetadataSystem.UserStrings.OrderBy (i => (uint)i.Key).ToList();
+		}
+
+		List<KeyValuePair<RVA, byte []>> GetAllBlobsSorted ()
+		{
+			return module.Image.BlobHeap.Blobs.OrderBy (i => (uint)i.Key).ToList ();
+		}
+
+		protected override void AttachTokens () 
+		{
+			// All tokens should be already assigned
+		}
+
+		protected override void BuildAssembly ()
+		{
+			foreach (var blob in GetAllBlobsSorted ())
+				GetBlobIndex (blob.Value);
+
+			base.BuildAssembly ();
+		}
+
+		protected override void AddTypes ()
+		{
+			foreach (var sig in GetAllStandaloneSigsSorted ()) {
+				var rva = GetBlobIndex (new SignatureWriter (sig.Value));
+				AddStandAloneSignature (rva);
+			}
+
+			foreach (var sig in GetAllUserStringsSorted ())
+				user_string_heap.GetStringIndex (sig.Value);
+
+			foreach (var typeRef in GetAllTypeRefsSorted ())
+				GetTypeRefToken (typeRef);
+
+			foreach (var typeRef in GetAllMemberRefsSorted ())
+				GetMemberRefToken (typeRef);
+
+			foreach (var field in GetAllFieldsSorted ())
+				AddField (field);
+
+			foreach (var method in GetAllMethodsSorted ())
+				AddMethod (method);
+
+			foreach (var type in GetAllTypesSorted ())
+				AddType (type);
+		}
+
+		protected override void AddNestedTypes (TypeDefinition type)
+		{
+			// Nested types are written in add order
+		}
+		protected override MetadataToken AddTypeReference (TypeReference type, TypeRefRow row)
+		{
+			type.token = new MetadataToken (TokenType.TypeRef, type_ref_table.AddRow (row));
+
+			var token = type.token;
+			type_ref_map.Add (row, token);
+			return token;
+		}
+
+		protected override SignatureWriter GetMethodSignature (IMethodSignature method)
+		{
+			if (method.RawSignature != null) {
+				return new SignatureWriter (method.RawSignature);
+			}
+			return base.GetMethodSignature (method);
+		}
+
+		protected override SignatureWriter GetFieldSignature (FieldReference field)
+		{
+			if (field is FieldDefinition fieldDef && fieldDef.RawSignature != null) {
+				return new SignatureWriter (fieldDef.RawSignature);
+			}
+			return base.GetFieldSignature (field);
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary of changes
Made `immediate` mode compatible with raw signatures and bodies.
Intended to be used in the [AoT POC](https://github.com/DataDog/dd-trace-dotnet/pull/5736), to produce pre instrumented assemblies on disk by using the Profiler offline.

## Implementation details
In immediate mode, all the metadata is read and stored, so when writing original values can be rewritten, instead of rebuilding everything as previously, so raw data produced from the native profiler can be used.